### PR TITLE
feat(ini): allow embedding

### DIFF
--- a/grafana.ini
+++ b/grafana.ini
@@ -2,3 +2,6 @@
 [dashboards]
 # Path to the default home dashboard. If this value is empty, then Grafana uses StaticRootPath + "dashboards/home.json"
 default_home_dashboard_path = /etc/grafana/provisioning/dashboards/main.dashboard.json
+
+[security]
+allow_embedding = true


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat-web/issues/847 . This adds a config line that tells the Grafana server to allow embedded panels, ex. via `<iframe>` element, on other pages (such as the Cryostat web-client). Without this, the Grafana server adds headers to requests that instruct web browsers to not load/render content cross-origin.

https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#allow_embedding