### PR TITLE
fix(dashboard): use fixed text color for stat panels

### DIFF
--- a/dashboards/main.dashboard.json
+++ b/dashboards/main.dashboard.json
@@ -24,7 +24,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "fixedColor": "text",
+            "mode": "fixed"
           },
           "decimals": 1,
           "mappings": [
@@ -36,19 +37,6 @@
               "value": "null"
             }
           ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "rgb(255, 255, 255)",
-                "value": 80
-              }
-            ]
-          },
           "unit": "ms"
         },
         "overrides": []
@@ -98,7 +86,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "fixedColor": "text",
+            "mode": "fixed"
           },
           "mappings": [
             {
@@ -109,19 +98,6 @@
               "value": "null"
             }
           ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "rgb(255, 255, 255)",
-                "value": ""
-              }
-            ]
-          },
           "unit": "dateTimeAsIso"
         },
         "overrides": []
@@ -185,7 +161,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "fixedColor": "text",
+            "mode": "fixed"
           },
           "mappings": [
             {
@@ -196,19 +173,6 @@
               "value": "null"
             }
           ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "rgb(255, 255, 255)",
-                "value": ""
-              }
-            ]
-          },
           "unit": "none"
         },
         "overrides": []
@@ -257,7 +221,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "fixedColor": "text",
+            "mode": "fixed"
           },
           "mappings": [
             {
@@ -268,19 +233,6 @@
               "value": "null"
             }
           ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "rgb(255, 255, 255)",
-                "value": ""
-              }
-            ]
-          },
           "unit": "none"
         },
         "overrides": []
@@ -329,7 +281,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "fixedColor": "text",
+            "mode": "fixed"
           },
           "mappings": [
             {
@@ -340,19 +293,6 @@
               "value": "null"
             }
           ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "rgb(255, 255, 255)",
-                "value": ""
-              }
-            ]
-          },
           "unit": "bytes"
         },
         "overrides": []
@@ -1579,22 +1519,10 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "text",
+                "mode": "fixed"
               },
               "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "rgb(255, 255, 255)",
-                    "value": ""
-                  }
-                ]
-              },
               "unit": "ms"
             },
             "overrides": []


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat-web/pull/856

This includes fix to panel text to specify single text color with text variant.

**Dark Theme**

![Screenshot from 2023-02-08 20-19-39](https://user-images.githubusercontent.com/68053619/217690350-d8463597-c8c5-4099-9d38-7ebd0db4d1b3.png)

**Light Theme**

![Screenshot from 2023-02-08 20-19-51](https://user-images.githubusercontent.com/68053619/217690368-d1ce5801-c6bb-4470-b1cb-a86b121b6543.png)

