### PR TITLE
build(container): rebase to centos9-stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream9-minimal
 
 EXPOSE 3000
 
-RUN dnf install -y grafana && /usr/sbin/grafana cli plugins install yesoreyeram-infinity-datasource
+RUN microdnf install -y grafana && /usr/sbin/grafana cli plugins install yesoreyeram-infinity-datasource
 
 COPY --chown=grafana:grafana \
     dashboards.yaml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,9 @@
 FROM quay.io/centos/centos:stream9-minimal
-
-EXPOSE 3000
-
-RUN microdnf install -y grafana && /usr/sbin/grafana cli plugins install yesoreyeram-infinity-datasource
-
-COPY --chown=grafana:grafana \
-    dashboards.yaml \
-    dashboards/*.dashboard.json \
-    /etc/grafana/provisioning/dashboards/
-
-COPY --chown=grafana:grafana \
-    datasource.yaml \
-    /etc/grafana/provisioning/datasources/
-
-COPY --chown=grafana:grafana \
-    grafana.ini \
-    /etc/grafana/grafana.ini
-
-COPY --chown=grafana:grafana \
-    entrypoint.bash \
-    /usr/share/grafana
+ARG UID=101
+ARG PORT=3000
 
 WORKDIR /usr/share/grafana
+ENV VERSION=10
 ENV GF_PATHS_HOME=/usr/share/grafana
 ENV HOME=/usr/share/grafana
 ENV GF_PATHS_PROVISIONING=/etc/grafana/provisioning
@@ -29,9 +11,45 @@ ENV GF_PATHS_DATA=/var/lib/grafana
 ENV GF_PATHS_LOGS=/var/log/grafana
 ENV GF_PATHS_PLUGINS=/var/lib/grafana/plugins
 ENV GF_PATHS_CONFIG=/etc/grafana/grafana.ini
+
+LABEL name="cryostat/cryostat-grafana-dashboard" \
+      version="${VERSION}" \
+      usage="podman run -d --name grafana -p ${PORT}:${PORT} -v grafana-data:${GF_PATHS_DATA} quay.io/cryostat/cryostat-grafana-dashboard" \
+      maintainer="Cryostat Maintainers <cryostat-development@googlegroups.com>" \
+      io.k8s.display-name="Grafana" \
+      io.openshift.expose-services="3000:grafana" \
+      io.openshift.tags="grafana,monitoring,dashboard"
+
+RUN useradd -u ${UID} -g 0 -r -d $GF_PATHS_HOME -s /sbin/nologin grafana && \
+    microdnf upgrade -y && \
+    microdnf install -y --setopt=tsflags=nodocs grafana && \
+    microdnf clean all && \
+    chgrp -R 0 /etc/grafana /var/lib/grafana /var/log/grafana && \
+    chmod -R g=u /var/lib/grafana /var/log/grafana && \
+    /usr/sbin/grafana cli plugins install yesoreyeram-infinity-datasource
+
+COPY --chown=grafana:grafana \
+    dashboards.yaml \
+    dashboards/*.dashboard.json \
+    ${GF_PATHS_PROVISIONING}/dashboards/
+
+COPY --chown=grafana:grafana \
+    datasource.yaml \
+    ${GF_PATHS_PROVISIONING}/datasources/
+
+COPY --chown=grafana:grafana \
+    grafana.ini \
+    ${GF_PATHS_CONFIG}
+
+COPY --chown=grafana:grafana \
+    entrypoint.bash \
+    /usr/bin/run-grafana
+
 # Listen address of jfr-datasource
 ENV JFR_DATASOURCE_URL "http://0.0.0.0:8080"
 
-USER grafana
+USER ${UID}
 
-ENTRYPOINT [ "/usr/share/grafana/entrypoint.bash" ]
+EXPOSE ${PORT}
+
+ENTRYPOINT [ "/usr/bin/run-grafana" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,37 @@
-FROM docker.io/grafana/grafana:10.4.3
+FROM quay.io/centos/centos:stream9
 
 EXPOSE 3000
 
-RUN grafana cli plugins install yesoreyeram-infinity-datasource
+RUN dnf install -y grafana && /usr/sbin/grafana cli plugins install yesoreyeram-infinity-datasource
 
-COPY --chown=grafana:root \
-	dashboards.yaml \
-	dashboards/*.dashboard.json \
-	/etc/grafana/provisioning/dashboards/
+COPY --chown=grafana:grafana \
+    dashboards.yaml \
+    dashboards/*.dashboard.json \
+    /etc/grafana/provisioning/dashboards/
 
-COPY --chown=grafana:root \
+COPY --chown=grafana:grafana \
     datasource.yaml \
     /etc/grafana/provisioning/datasources/
 
-COPY --chown=grafana:root \
+COPY --chown=grafana:grafana \
     grafana.ini \
     /etc/grafana/grafana.ini
 
+COPY --chown=grafana:grafana \
+    entrypoint.bash \
+    /usr/share/grafana
+
+WORKDIR /usr/share/grafana
+ENV GF_PATHS_HOME=/usr/share/grafana
+ENV HOME=/usr/share/grafana
+ENV GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+ENV GF_PATHS_DATA=/var/lib/grafana
+ENV GF_PATHS_LOGS=/var/log/grafana
+ENV GF_PATHS_PLUGINS=/var/lib/grafana/plugins
+ENV GF_PATHS_CONFIG=/etc/grafana/grafana.ini
 # Listen address of jfr-datasource
 ENV JFR_DATASOURCE_URL "http://0.0.0.0:8080"
 
-# User grafana
-USER 472
+USER grafana
 
-ENTRYPOINT [ "/run.sh" ]
+ENTRYPOINT [ "/usr/share/grafana/entrypoint.bash" ]

--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-exec /usr/sbin/grafana server                               \
+exec /usr/sbin/grafana-server                               \
   --homepath="$GF_PATHS_HOME"                               \
   --config="$GF_PATHS_CONFIG"                               \
   --packaging=docker                                        \

--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+exec /usr/sbin/grafana server                               \
+  --homepath="$GF_PATHS_HOME"                               \
+  --config="$GF_PATHS_CONFIG"                               \
+  --packaging=docker                                        \
+  "$@"                                                      \
+  cfg:default.log.mode="console"                            \
+  cfg:default.paths.data="$GF_PATHS_DATA"                   \
+  cfg:default.paths.logs="$GF_PATHS_LOGS"                   \
+  cfg:default.paths.plugins="$GF_PATHS_PLUGINS"             \
+  cfg:default.paths.provisioning="$GF_PATHS_PROVISIONING"


### PR DESCRIPTION
Replaces base image with centos9-stream for easier synchronization of upstream and downstream builds.

To test:
```bash
$ ./build.sh
$ cd /path/to/cryostat
$ ./smoketest.bash -O
$ # wait for everything to come up, then go to https://localhost:8443, log in, select Cryostat itself, then "View in Grafana" one of the startup recordings. Verify that the Grafana dashboard loads as expected
```